### PR TITLE
Change conflict resolution instructions

### DIFF
--- a/src/lineage/templates/conflict_template.md
+++ b/src/lineage/templates/conflict_template.md
@@ -41,7 +41,9 @@ that you must resolve before merging this pull request!
 
     ```console
     git add {{#conflict_file_list}}{{.}} {{/conflict_file_list}}
-    git commit --message="Resolve Lineage conflicts."
+    # You may append to the default merge commit message that git creates for
+    # you, but _do not_ overwrite it.  The content it provides is useful.
+    git commit
     git push --force --set-upstream origin {{ pr_branch_name }}
     ```
 

--- a/src/lineage/templates/conflict_template.md
+++ b/src/lineage/templates/conflict_template.md
@@ -36,16 +36,19 @@ that you must resolve before merging this pull request!
 1. Review the changes displayed by the `status` command.  Fix any conflicts and
    possibly incorrect auto-merges.
 
-1. After resolving each of the conflicts, `add` your changes to the branch,
-   `commit`, and `push` your changes:
+1. After resolving each of the conflicts, `add` your changes to the
+   branch, `commit`, and `push` your changes:
 
     ```console
     git add {{#conflict_file_list}}{{.}} {{/conflict_file_list}}
-    # You may append to the default merge commit message that git creates for
-    # you, but _do not_ overwrite it.  The content it provides is useful.
     git commit
     git push --force --set-upstream origin {{ pr_branch_name }}
     ```
+
+    Note that you may _append_ to the default merge commit message
+    that git creates for you, but *please do not delete the existing
+    content*.  It provides useful information about the merge that is
+    being performed.
 
 1. Wait for all the automated tests to pass.
 


### PR DESCRIPTION
## 🗣 Description

Tell the users to feel free to _append_ to the default merge commit message that `git` creates for them, but insist that they _do not_ completely overwrite it.

## 💭 Motivation and Context

The content the default merge commit message from `git` provides is useful and we should keep it around.

## 🧪 Testing

App pre-commit hooks pass.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
