### PR TITLE
Apply Desired Labels to Generated PRs

### DIFF
--- a/src/lineage/entrypoint.py
+++ b/src/lineage/entrypoint.py
@@ -21,6 +21,7 @@ ALREADY_UP_TO_DATE = "Already up to date."
 CONFIG_FILENAME = ".github/lineage.yml"
 CODEOWNERS_FILENAME = ".github/CODEOWNERS"
 GIT = "/usr/bin/git"
+PR_LABEL_NAMES = ["upstream update"]
 PR_METADATA = 'lineage:metadata:{"slayed":true}'
 UNRELATED_HISTORY = "fatal: refusing to merge unrelated histories"
 
@@ -219,6 +220,14 @@ def create_pull_request(
     for owner in get_code_owners(repo):
         logging.info(f"Assigning code owner {owner} to pull request.")
         pull_request.add_to_assignees(owner)
+
+    # Build a list of labels to add from the labels available in the repository
+    # and the list of desired labels
+    repo_labels = repo.get_labels()
+    pr_labels = [label for label in repo_labels if label.name in PR_LABEL_NAMES]
+    if pr_labels:
+        # Assign desired labels to pull request
+        pull_request.add_to_labels(*pr_labels)
 
 
 def get_code_owners(repo: Repository.Repository) -> Generator[str, None, None]:


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds functionality to add desired labels, if they are available in the repository, to a generated PR. This will close #23 and automate one more part of the skeleton updating process.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

#23 has been up for a bit, and the functionality came up again during our latest round of 🐙ing.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I tested the piece I added on it's own in my own repository.
<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
