### PR TITLE
Use chevron Instead of pystache for Templating

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ setup(
     package_data={"lineage": ["templates/*.md"]},
     py_modules=[splitext(basename(path))[0] for path in glob("src/*.py")],
     include_package_data=True,
-    install_requires=["PyGithub", "pystache", "PyYAML", "setuptools >= 24.2.0"],
+    install_requires=["chevron", "PyGithub", "PyYAML", "setuptools >= 24.2.0"],
     extras_require={
         "test": [
             "coverage",

--- a/src/lineage/entrypoint.py
+++ b/src/lineage/entrypoint.py
@@ -11,9 +11,9 @@ from typing import Generator, List, Optional, Tuple
 from urllib.parse import ParseResult, urlparse
 
 # Third-Party Libraries
+import chevron
 from github import Github, PullRequest, Repository
 import pkg_resources
-import pystache
 import requests
 import yaml
 
@@ -372,13 +372,13 @@ def main() -> None:
                     }
                     if conflict_file_list:
                         title = f"⚠️ CONFLICT! Lineage pull request for: {lineage_id}"
-                        body = pystache.render(conflict_template, template_data)
+                        body = chevron.render(conflict_template, template_data)
                         create_pull_request(
                             repo, pr_branch_name, local_branch, title, body, draft=True
                         )
                     else:
                         title = f"Lineage pull request for: {lineage_id}"
-                        body = pystache.render(clean_template, template_data)
+                        body = chevron.render(clean_template, template_data)
                         create_pull_request(
                             repo, pr_branch_name, local_branch, title, body, draft=False
                         )


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR replaces [defunkt/pystache](https://github.com/defunkt/pystache) with [noahmorrison/chevron](https://github.com/noahmorrison/chevron) for rendering [mustache](https://mustache.github.io/) templates.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The `pystache` package's last release was [2014-05-12](https://pypi.org/project/pystache/0.5.4/) while the `chevron` package's last release was [2021-01-02](https://pypi.org/project/chevron/0.14.0/). This difference in continued development should be reason enough to change. In https://github.com/mustache/mustache.github.com/pull/120 the recommended Python package for mustache templating was updated from `pystache` to `chevron`. As a last bonus:
> ["Chevron runs in less than half the time of pystache (Which is not even up to date on the spec). And in about 70% the time of Stache (A 'trimmed' version of mustache, also not spec compliant)."](https://github.com/noahmorrison/chevron#chevron-is-fast)

This is a "test run" of transitioning to using `chevron` for any of our mustache templating. I think it will be beneficial to switch to a maintained package that is claimed to be substantially faster than our current package choice.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
Automated tests pass successfully. But wait, there's more!

### Generate rendered files with Python ###

```console
>>> import chevron
>>> template_data = {
...   "conflict_file_list": ["foo.py", "bar.sh"],
...   "lineage_id": "skeleton",
...   "local_branch": "develop",
...   "metadata": 'lineage:metadata:{"slayed":true}',
...   "pr_branch_name": "lineage/skeleton",
...   "remote_branch": "HEAD",
...   "remote_url": "https://github.com/cisagov/skeleton-python-library.git",
...   "repo_name": "action-lineage",
...   "ssh_url": "git@github.com:cisagov/action-lineage.git",
... }
>>> with open("src/lineage/templates/clean_template.md") as f:
...   clean_template = f.read()
...
>>> with open("src/lineage/templates/conflict_template.md") as f:
...   conflict_template = f.read()
...
>>> clean_body = chevron.render(clean_template, template_data)
>>> conflict_body = chevron.render(conflict_template, template_data)
>>> with open("clean_rendered.md", "w") as f:
...   f.write(clean_body)
...
792
>>> with open("conflict_rendered.md", "w") as f:
...   f.write(conflict_body)
...
2397
>>> import pystache
>>> clean_body = pystache.render(clean_template, template_data)
>>> conflict_body = pystache.render(conflict_template, template_data)
>>> with open("clean_rendered_pystache.md", "w") as f:
...   f.write(clean_body)
...
792
>>> with open("conflict_rendered_pystache.md", "w") as f:
...   f.write(conflict_body)
...
2397
>>>
```

### Compare the rendered files ###

```console
$ diff clean_rendered.md clean_rendered_pystache.md
$ diff conflict_rendered.md conflict_rendered_pystache.md
```
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
