### PR TITLE
Gracefully Handle a Repository Failing to Clone

### DIFF
--- a/src/lineage/entrypoint.py
+++ b/src/lineage/entrypoint.py
@@ -91,7 +91,12 @@ def get_repo_list(
 ) -> Generator[Repository.Repository, None, None]:
     """Generate a list of repositories based on the query."""
     logging.info(f"Querying for repositories: {repo_query}")
-    matching_repos = g.search_repositories(query=repo_query)
+    # Sometimes there is an issue with the pagination of results from the
+    # call to `Github.search_repositories()` that causes repositories on page
+    # breaks to be duplicated when iterating over results. The only issue I could
+    # find that referenced this problem is
+    # https://github.com/PyGithub/PyGithub/issues/1748
+    matching_repos = g.search_repositories(query=repo_query, sort="updated")
     for repo in matching_repos:
         yield repo
 

--- a/src/lineage/entrypoint.py
+++ b/src/lineage/entrypoint.py
@@ -95,7 +95,12 @@ def get_repo_list(
     # call to `Github.search_repositories()` that causes repositories on page
     # breaks to be duplicated when iterating over results. The only issue I could
     # find that referenced this problem is
-    # https://github.com/PyGithub/PyGithub/issues/1748
+    # https://github.com/PyGithub/PyGithub/issues/1748,
+    # which suggests that adding the sort="updated" parameter to the
+    # `Github.search_repositories()` call helps. Hence I am adding it here.
+    #
+    # See also pull request #33 in this repository:
+    # https://github.com/cisagov/action-lineage/pull/33
     matching_repos = g.search_repositories(query=repo_query, sort="updated")
     for repo in matching_repos:
         yield repo
@@ -320,7 +325,14 @@ def main() -> None:
         logging.info(f"Lineage configuration found for {repo.full_name}")
         logging.info(f"Cloning repository: {repo.clone_url}")
         # The failure of a repository to clone should not cause the entire
-        # run to fail.
+        # run to fail. See related comment above in the body of the
+        # get_repo_list() function for an example of such a case which caused an
+        # exception with the following error when attempting to clone:
+        # fatal: destination path 'repo_full_name' already exists and is not an
+        # empty directory.
+        #
+        # See also pull request #33 in this repository:
+        # https://github.com/cisagov/action-lineage/pull/33
         try:
             run([GIT, "clone", repo.clone_url, repo.full_name])
         except Exception as err:

--- a/src/lineage/entrypoint.py
+++ b/src/lineage/entrypoint.py
@@ -319,7 +319,14 @@ def main() -> None:
             continue
         logging.info(f"Lineage configuration found for {repo.full_name}")
         logging.info(f"Cloning repository: {repo.clone_url}")
-        run([GIT, "clone", repo.clone_url, repo.full_name])
+        # The failure of a repository to clone should not cause the entire
+        # run to fail.
+        try:
+            run([GIT, "clone", repo.clone_url, repo.full_name])
+        except Exception as err:
+            logging.warning("Unable to clone %s.", repo.full_name)
+            logging.warning(err)
+            continue
         lineage_id: str
         local_branch: str
         remote_branch: Optional[str]


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR does two things:

1. Update the search used to find appropriate repositories to attempt to make it more deterministic.
2. Make sure that a failure of a `git clone` is handled gracefully.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

There has been an occasional, but recurrent, issue where there are times that a repository is processed twice. This shows up in Actions runs such as https://github.com/cisagov/action-lineage/runs/3279770102?check_suite_focus=true as the error `CRITICAL fatal: destination path 'full_repo_name' already exists and is not an empty directory.`. After looking into the issue I noticed that the repository it failed on was on the page boundary with the default result size (30). This led me to investigate pagination as a possible culprit. I was unable to find anything definitive, but I applied the one change suggested in https://github.com/PyGithub/PyGithub/issues/1748 and wrapped the call to `git clone` in a `try`/`except` to prevent any cloning issue from causing the entire process to fail.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
Automated testing passes and I checked that the call to `Github.search_repositories()` is successful in the Python command line.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
