### PR TITLE
Safely Access Dictionary Key in Logging Output

### DIFF
--- a/src/lineage/entrypoint.py
+++ b/src/lineage/entrypoint.py
@@ -344,7 +344,7 @@ def main() -> None:
         remote_branch: Optional[str]
         remote_url: str
         if config.get("version") != "1":
-            logging.warning(f"Incompatible config version: {config['version']}")
+            logging.warning(f"Incompatible config version: {config.get('version')}")
             continue
         if "lineage" not in config:
             logging.warning("Could not find 'lineage' key in config.")


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This changes a dictionary access to use the `get()` method so a default value is returned if the key is missing.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

GitHub Actions runs for the `lineage_scan` workflow are currently failing because [cisagov/con-pca-api](https://github.com/cisagov/con-pca-api) is missing the `version` field in its `.github/lineage.yml` file and we do not safely access that key in the parsed configuration dictionary. This can be seen [at this point in the log](https://github.com/cisagov/action-lineage/runs/3748038515?check_suite_focus=true#step:3:37). Although that repository needs to be fixed, it should not result in a failing state for this Action.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
Automated tests pass.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
