### PR TITLE
Use Library for GitHub Actions Functionality and Allow Manual `lineage_scan` Runs

### DIFF
--- a/.github/workflows/lineage_scan.yml
+++ b/.github/workflows/lineage_scan.yml
@@ -4,6 +4,7 @@ name: lineage_scan
 on:
   schedule:
     - cron: "15 * * * *"
+  workflow_dispatch:
 
 env:
   ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,13 @@ setup(
     package_data={"lineage": ["templates/*.md"]},
     py_modules=[splitext(basename(path))[0] for path in glob("src/*.py")],
     include_package_data=True,
-    install_requires=["chevron", "PyGithub", "PyYAML", "setuptools >= 24.2.0"],
+    install_requires=[
+        "actions-toolkit",
+        "chevron",
+        "PyGithub",
+        "PyYAML",
+        "setuptools >= 24.2.0",
+    ],
     extras_require={
         "test": [
             "coverage",

--- a/src/lineage/entrypoint.py
+++ b/src/lineage/entrypoint.py
@@ -11,6 +11,7 @@ from typing import Generator, List, Optional, Tuple
 from urllib.parse import ParseResult, urlparse
 
 # Third-Party Libraries
+from actions_toolkit import core
 import chevron
 from github import Github, PullRequest, Repository
 import pkg_resources
@@ -272,10 +273,10 @@ def main() -> None:
     logging.basicConfig(format="%(levelname)s %(message)s", level="INFO")
 
     # Get inputs from the environment
-    access_token: Optional[str] = os.environ.get("INPUT_ACCESS_TOKEN")
+    access_token: Optional[str] = core.get_input("access_token")
     github_actor: Optional[str] = os.environ.get("GITHUB_ACTOR")
     github_workspace_dir: Optional[str] = os.environ.get("GITHUB_WORKSPACE")
-    repo_query: Optional[str] = os.environ.get("INPUT_REPO_QUERY")
+    repo_query: Optional[str] = core.get_input("repo_query")
 
     # sanity checks
     if access_token is None:


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR makes two changes:
- Adds the [yanglbme/actions-toolkit](https://github.com/yanglbme/actions-toolkit) library to provide an interface for GitHub Actions functionality.
- Adds `workflow_dispatch` functionality to the `lineage_scan` workflow so it can be manually triggered.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The [yanglbme/actions-toolkit](https://github.com/yanglbme/actions-toolkit) library provides a Python implementation of the GitHub maintained [actions/toolkit](https://github.com/actions/toolkit) JavaScript project. Currently it only has the `actions.core` package implemented, but this is also the functionality we are most interested in using. While we are only using the functionality to get Action inputs right now, I have plans to leverage more of the GitHub Actions functionality available and this library will provide a clean means to do so.

Adding a `workflow_dispatch` trigger to the `lineage_scan` workflow allows us to manually trigger a run either in the GitHub web UI or by using the GitHub CLI. This will provide some flexibility when a skeleton has a number of PRs to merge and tests take a notable amount of time to manually trigger the workflow if a scheduled run has processed mid-merges.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
Automated tests pass. A manually triggered `lineage_scan` run was successful.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
