### PR TITLE
Control Non-Public Repository Processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,20 +42,20 @@ lineage:
 
 ### Inputs ###
 
-| Name | Description | Default | Required |
-| ---- | ----------- | ------- | :------: |
-| access_token | GitHub personal access token. | n/a | yes |
-| mask_non_public_repos | Control the visibility of private repo names in the logs. | `true` | no |
-| public_repos_only | Control non-public repository processing. | `true` | no |
-| repo_query | GitHub search query to find repositories for pull requests. | n/a | yes |
+| Name | Description | Interpreted Type | Default | Required |
+| ---- | ----------- | ---------------- | ------- | :------: |
+| access_token | GitHub personal access token. | `string` | n/a | yes |
+| mask_non_public_repos | Control the visibility of private repo names in the logs. | [`boolean`](https://yaml.org/spec/1.2.2/#1032-tag-resolution) | `true` | no |
+| public_repos_only | Control non-public repository processing. | [`boolean`](https://yaml.org/spec/1.2.2/#1032-tag-resolution) | `true` | no |
+| repo_query | GitHub search query to find repositories for pull requests. | `string` | n/a | yes |
 
 ### Outputs ###
 
 None.
 <!--
-| Name | Description |
-| ---- | ----------- |
-| output_name | The output's description. |
+| Name | Description | Output Type |
+| ---- | ----------- | ----------- |
+| output_name | The output's description. | `output_type` |
 -->
 
 ### Sample GitHub Actions workflow ###

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Lineage is configured using `.github/lineage.yml` in a repository.  Each
 upstream repository is listed in the `lineage` section.
 
 | Key | Description | Required |
-|-----|-------------|----------|
+|-----|-------------|:--------:|
 | local-branch | The branch that will receive new changes. | No |
 | remote-url   | The `https` URL of the upstream repository. | Yes |
 | remote-branch | The branch in the upstream repository. | No |
@@ -43,7 +43,7 @@ lineage:
 ### Inputs ###
 
 | Name | Description | Interpreted Type | Default | Required |
-| ---- | ----------- | ---------------- | ------- | :------: |
+|------|-------------|------------------|---------|:--------:|
 | access_token | GitHub personal access token (see [GitHub's documentation](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)). | `string` | n/a | yes |
 | mask_non_public_repos | Control the visibility of private repo names in the logs. | [`boolean`](https://yaml.org/spec/1.2.2/#1032-tag-resolution) | `true` | no |
 | public_repos_only | Control non-public repository processing. | [`boolean`](https://yaml.org/spec/1.2.2/#1032-tag-resolution) | `true` | no |
@@ -54,7 +54,7 @@ lineage:
 None.
 <!--
 | Name | Description | Output Type |
-| ---- | ----------- | ----------- |
+|------|-------------|-------------|
 | output_name | The output's description. | `output_type` |
 -->
 

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ lineage:
 | Name | Description | Interpreted Type | Default | Required |
 |------|-------------|------------------|---------|:--------:|
 | access_token | GitHub personal access token (see [GitHub's documentation](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)). | `string` | n/a | yes |
-| mask_non_public_repos | Control the visibility of private repo names in the logs. | [`boolean`](https://yaml.org/spec/1.2.2/#1032-tag-resolution) | `true` | no |
-| public_repos_only | Control non-public repository processing. | [`boolean`](https://yaml.org/spec/1.2.2/#1032-tag-resolution) | `true` | no |
-| repo_query | GitHub search query to find repositories for pull requests (e.g. "org:cisagov archived:false"). | `string` | n/a | yes |
+| mask_non_public_repos | Whether to mask the names of non-public (`private` and `internal`) repositories in the GitHub Actions logs. | [`boolean`](https://yaml.org/spec/1.2.2/#1032-tag-resolution) | `true` | no |
+| include_non_public_repos | Whether to process non-public (`private` and `internal`) repositories. | [`boolean`](https://yaml.org/spec/1.2.2/#1032-tag-resolution) | `false` | no |
+| repo_query | GitHub search query to use when finding repositories for which to create pull requests (e.g. \"org:cisagov archived:false\"). | `string` | n/a | yes |
 
 ### Outputs ###
 

--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ lineage:
 
 | Name | Description | Interpreted Type | Default | Required |
 | ---- | ----------- | ---------------- | ------- | :------: |
-| access_token | GitHub personal access token. | `string` | n/a | yes |
+| access_token | GitHub personal access token (see [GitHub's documentation](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)). | `string` | n/a | yes |
 | mask_non_public_repos | Control the visibility of private repo names in the logs. | [`boolean`](https://yaml.org/spec/1.2.2/#1032-tag-resolution) | `true` | no |
 | public_repos_only | Control non-public repository processing. | [`boolean`](https://yaml.org/spec/1.2.2/#1032-tag-resolution) | `true` | no |
-| repo_query | GitHub search query to find repositories for pull requests. | `string` | n/a | yes |
+| repo_query | GitHub search query to find repositories for pull requests (e.g. "org:cisagov archived:false"). | `string` | n/a | yes |
 
 ### Outputs ###
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,27 @@ lineage:
     remote-url: https://github.com/felddy/extra-skel-sauce.git
 ```
 
-## Sample GitHub Actions workflow ##
+## Usage ##
+
+### Inputs ###
+
+| Name | Description | Default | Required |
+| ---- | ----------- | ------- | :------: |
+| access_token | GitHub personal access token. | n/a | yes |
+| mask_non_public_repos | Control the visibility of private repo names in the logs. | `true` | no |
+| public_repos_only | Control non-public repository processing. | `true` | no |
+| repo_query | GitHub search query to find repositories for pull requests. | n/a | yes |
+
+### Outputs ###
+
+None.
+<!--
+| Name | Description |
+| ---- | ----------- |
+| output_name | The output's description. |
+-->
+
+### Sample GitHub Actions workflow ###
 
 The Lineage action requires a personal access token so that it may open pull
 requests.  For public repositories this token must have the `public_repo`

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,14 @@ inputs:
   access_token:
     description: "GitHub personal access token."
     required: true
+  mask_non_public_repos:
+    default: true
+    description: "Control the visibility of private repo names in the logs."
+    required: false
+  public_repos_only:
+    default: true
+    description: "Control non-public repository processing."
+    required: false
   repo_query:
     description: "GitHub search query to find repositories for pull requests."
     required: true

--- a/action.yml
+++ b/action.yml
@@ -12,14 +12,17 @@ inputs:
     required: true
   mask_non_public_repos:
     default: true
-    description: "Control the visibility of private repo names in the logs."
+    description: "Whether to mask the names of non-public (`private` and
+      `internal`) repositories in the GitHub Actions logs."
     required: false
-  public_repos_only:
-    default: true
-    description: "Control non-public repository processing."
+  include_non_public_repos:
+    default: false
+    description: "Whether to process non-public (`private` and `internal`)
+      repositories."
     required: false
   repo_query:
-    description: "GitHub search query to find repositories for pull requests."
+    description: "GitHub search query to use when finding repositories for
+      which to create pull requests (e.g. \"org:cisagov archived:false\")."
     required: true
 runs:
   using: "docker"

--- a/src/lineage/entrypoint.py
+++ b/src/lineage/entrypoint.py
@@ -281,7 +281,7 @@ def main() -> None:
     github_workspace_dir: Optional[str] = os.environ.get("GITHUB_WORKSPACE")
     mask_non_public: bool = core.get_boolean_input("mask_non_public_repos")
     repo_query: Optional[str] = core.get_input("repo_query")
-    public_only: bool = core.get_boolean_input("public_repos_only")
+    include_non_public: bool = core.get_boolean_input("include_non_public_repos")
 
     # sanity checks
     if access_token is None:
@@ -325,7 +325,7 @@ def main() -> None:
     for repo in repos:
         # Extra controls if the repo is private
         if repo.private:
-            if public_only:
+            if not include_non_public:
                 continue
             # Ensure that non-public repo names do not show up in the logs
             if mask_non_public:

--- a/src/lineage/entrypoint.py
+++ b/src/lineage/entrypoint.py
@@ -269,8 +269,11 @@ def get_code_owners(repo: Repository.Repository) -> Generator[str, None, None]:
 
 def main() -> None:
     """Parse environment and perform requested actions."""
-    # Set up logging
-    logging.basicConfig(format="%(levelname)s %(message)s", level="INFO")
+    # Set up logging. Force logging output to stdout to allow for GitHub Actions
+    # commands to interact with output.
+    logging.basicConfig(
+        format="%(levelname)s %(message)s", level=logging.INFO, stream=sys.stdout
+    )
 
     # Get inputs from the environment
     access_token: Optional[str] = core.get_input("access_token")

--- a/src/lineage/entrypoint.py
+++ b/src/lineage/entrypoint.py
@@ -276,7 +276,9 @@ def main() -> None:
     access_token: Optional[str] = core.get_input("access_token")
     github_actor: Optional[str] = os.environ.get("GITHUB_ACTOR")
     github_workspace_dir: Optional[str] = os.environ.get("GITHUB_WORKSPACE")
+    mask_non_public: bool = core.get_boolean_input("mask_non_public_repos")
     repo_query: Optional[str] = core.get_input("repo_query")
+    public_only: bool = core.get_boolean_input("public_repos_only")
 
     # sanity checks
     if access_token is None:
@@ -318,6 +320,13 @@ def main() -> None:
 
     repos = get_repo_list(g, repo_query)
     for repo in repos:
+        # Extra controls if the repo is private
+        if repo.private:
+            if public_only:
+                continue
+            # Ensure that non-public repo names do not show up in the logs
+            if mask_non_public:
+                core.set_secret(repo.full_name)
         logging.info(f"Checking: {repo.full_name}")
         config = get_config(repo)
         if not config:


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds controls for two things:
- Whether or not to process non-public repositories (default: public only).
- If processing non-public repositories, whether or not to output those repository names in logging (default: mask repository names).

It also adds information about the Action's inputs/outputs to the README as that information was missing.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

We should neither process private repositories nor leak information about private repositories unless it is specifically enabled. The README should contain information about the Action's inputs/outputs for convenience and good documenting.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
Automated tests pass. I tested that the two controls work as expected with manual `lineage_scan` runs.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
