### PR TITLE
Add a Warning Annotation to GitHub Actions Logs

### DIFF
--- a/src/lineage/entrypoint.py
+++ b/src/lineage/entrypoint.py
@@ -425,7 +425,7 @@ def main() -> None:
             # If the branch already exists, then check if a PR exists
             if not branch_is_new and not has_existing_pr(repo, pr_branch_name):
                 core.warning(
-                    "There is no Pull Request for the existing Lineage branch.",
+                    "There is no pull request for the existing Lineage branch.",
                     title=repo.full_name,
                 )
             fetch(repo, remote_url, remote_branch)

--- a/src/lineage/entrypoint.py
+++ b/src/lineage/entrypoint.py
@@ -275,6 +275,16 @@ def get_code_owners(repo: Repository.Repository) -> Generator[str, None, None]:
             break
 
 
+def has_existing_pr(repo: Repository.Repository, branch_name: str) -> bool:
+    """Check if an open PR already exists for the lineage branch."""
+    # By default only open Pull Requests are returned
+    pull_requests = repo.get_pulls()
+    for pr in pull_requests:
+        if pr.head.ref == branch_name:
+            return True
+    return False
+
+
 def main() -> None:
     """Parse environment and perform requested actions."""
     # Set up logging. Force logging output to stdout to allow for GitHub Actions
@@ -412,6 +422,12 @@ def main() -> None:
                 repo, lineage_id, local_branch
             )
             logging.info("Pull request branch is new: %s", branch_is_new)
+            # Check if a PR exists if the branch already exists
+            if not branch_is_new and not has_existing_pr(repo, pr_branch_name):
+                core.warning(
+                    "There is no Pull Request for the existing Lineage branch.",
+                    title=repo.full_name,
+                )
             fetch(repo, remote_url, remote_branch)
             changed: bool
             conflict_file_list: List[str]

--- a/src/lineage/entrypoint.py
+++ b/src/lineage/entrypoint.py
@@ -422,7 +422,7 @@ def main() -> None:
                 repo, lineage_id, local_branch
             )
             logging.info("Pull request branch is new: %s", branch_is_new)
-            # Check if a PR exists if the branch already exists
+            # If the branch already exists, then check if a PR exists
             if not branch_is_new and not has_existing_pr(repo, pr_branch_name):
                 core.warning(
                     "There is no Pull Request for the existing Lineage branch.",


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds a warning annotation to the GitHub Actions logs if a repository already has a [cisagov/action-lineage](https://github.com/cisagov/action-lineage) branch but there is no accompanying Pull Request.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

@jsf9k Noticed a repository that did not get a new Lineage PR as expected in our latest round of krakening. Upon investigation I realized that a `lineage/skeleton` branch existed and was being updated, but there was no PR attached to it for review. I thought it would be good to add this check into Lineage itself to make it easier to notice this kind of problem in the future.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
Automated tests pass. Please see [this Actions run](https://github.com/cisagov/action-lineage/actions/runs/1399461559) for an example run.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
