### PR TITLE
Update failing Dockerfile configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG GIT_COMMIT=unspecified
 ARG GIT_REMOTE=unspecified
 ARG VERSION=unspecified
 
-FROM python:alpine
+FROM python:3.10-alpine
 
 ARG GIT_COMMIT
 ARG GIT_REMOTE

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,6 @@ LABEL org.opencontainers.image.version=${VERSION}
 
 COPY . ./
 RUN apk add --no-cache build-base git libffi-dev
-RUN pip install --requirement requirements.txt
+RUN python3 -m pip install --no-cache-dir --upgrade pip setuptools wheel
+RUN pip install --no-cache-dir --requirement requirements.txt
 ENTRYPOINT ["python3", "-m", "lineage"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,12 @@ ARG GIT_COMMIT
 ARG GIT_REMOTE
 ARG VERSION
 
-LABEL org.opencontainers.image.authors="@felddy"
+LABEL org.opencontainers.image.authors="@felddy @mcdonnnj"
 LABEL org.opencontainers.image.licenses="CC0-1.0"
 LABEL org.opencontainers.image.revision=${GIT_COMMIT}
 LABEL org.opencontainers.image.source=${GIT_REMOTE}
 LABEL org.opencontainers.image.title="Lineage GitHub Action"
-LABEL org.opencontainers.image.vendor="Cyber and Infrastructure Security Agency"
+LABEL org.opencontainers.image.vendor="Cybersecurity and Infrastructure Security Agency"
 LABEL org.opencontainers.image.version=${VERSION}
 
 COPY . ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,6 @@ LABEL org.opencontainers.image.vendor="Cyber and Infrastructure Security Agency"
 LABEL org.opencontainers.image.version=${VERSION}
 
 COPY . ./
-RUN apk add git
+RUN apk add --no-cache build-base git libffi-dev
 RUN pip install --requirement requirements.txt
 ENTRYPOINT ["python3", "-m", "lineage"]


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the Docker configuration used to run this Python project as a GitHub Action. It includes:

- Pinning the base Docker image.
- Installing system packages necessary for the [cffi Python package](https://pypi.org/project/cffi/).
- Upgrading the core Python packages [pip](https://pypi.org/project/pip/), [setuptools](https://pypi.org/project/setuptools/), and [wheel](https://pypi.org/project/wheel/).
- Disable caching for all installation steps in keeping with Dockerfile best practices.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The main cause of this update is because the `lineage_scan` workflow is in a state of failure because the Docker image for this project is unable to build. The root cause is a lack of build tools for the [cffi Python package](https://pypi.org/project/cffi/). While updating to resolve that I decided to do some other housekeeping to hopefully prevent unexpected failures of this nature in the future.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. A [`lineage_scan` run with this branch](https://github.com/cisagov/action-lineage/actions/runs/1674833045) was successful.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
