### PR TITLE
Add cisagov's standard PR checklists to the Lineage templates

### DIFF
--- a/src/lineage/_version.py
+++ b/src/lineage/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this module."""
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/src/lineage/templates/clean_template.md
+++ b/src/lineage/templates/clean_template.md
@@ -16,7 +16,6 @@ your project.
 <!-- If you're unsure about any of these, don't hesitate to ask. -->
 <!-- We're here to help! -->
 
-- [ ] ✌️ The conflicts in this pull request have been resolved.
 - [ ] Changes are limited to a single goal - *eschew scope creep!*
 - [ ] *All* future TODOs are captured in issues, which are referenced
       in code comments.

--- a/src/lineage/templates/clean_template.md
+++ b/src/lineage/templates/clean_template.md
@@ -14,12 +14,9 @@ your project.
 - Remove any of the following that do not apply.
 - If you're unsure about any of these, don't hesitate to ask. We're here to help!
 
-- [ ] Changes are limited to a single goal - *eschew scope creep!*
 - [ ] *All* future TODOs are captured in issues, which are referenced
       in code comments.
 - [ ] All relevant type-of-change labels have been added.
-- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
-- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
 - [ ] All relevant repo and/or project documentation has been updated
       to reflect the changes in this PR.
 - [ ] Tests have been added and/or modified to cover the changes in this PR.

--- a/src/lineage/templates/clean_template.md
+++ b/src/lineage/templates/clean_template.md
@@ -9,6 +9,40 @@ Upstream repository: [`{{ remote_url }}`]({{ remote_url }})
 Check the changes in this pull request to ensure they won't cause issues with
 your project.
 
+## ✅ Pre-approval checklist ##
+
+<!-- Remove any of the following that do not apply. -->
+<!-- Draft PRs should have one or more unchecked boxes. -->
+<!-- If you're unsure about any of these, don't hesitate to ask. -->
+<!-- We're here to help! -->
+
+- [ ] ✌️ The conflicts in this pull request have been resolved.
+- [ ] Changes are limited to a single goal - *eschew scope creep!*
+- [ ] *All* future TODOs are captured in issues, which are referenced
+      in code comments.
+- [ ] All relevant type-of-change labels have been added.
+- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
+- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
+- [ ] All relevant repo and/or project documentation has been updated
+      to reflect the changes in this PR.
+- [ ] Tests have been added and/or modified to cover the changes in this PR.
+- [ ] All new and existing tests pass.
+
+## ✅ Pre-merge checklist ##
+
+<!-- Remove any of the following that do not apply. -->
+<!-- These boxes should remain unchecked until the pull request has been -->
+<!-- approved. -->
+
+- [ ] Bump version via the `bump_version.sh` script, if this
+      repository is versioned.
+
+## ✅ Post-merge checklist ##
+
+<!-- Remove any of the following that do not apply. -->
+
+- [ ] Create a release.
+
 ---
 
 **Note:** *You are seeing this because one of this repository's maintainers has

--- a/src/lineage/templates/clean_template.md
+++ b/src/lineage/templates/clean_template.md
@@ -11,10 +11,8 @@ your project.
 
 ## ✅ Pre-approval checklist ##
 
-<!-- Remove any of the following that do not apply. -->
-<!-- Draft PRs should have one or more unchecked boxes. -->
-<!-- If you're unsure about any of these, don't hesitate to ask. -->
-<!-- We're here to help! -->
+- Remove any of the following that do not apply.
+- If you're unsure about any of these, don't hesitate to ask. We're here to help!
 
 - [ ] Changes are limited to a single goal - *eschew scope creep!*
 - [ ] *All* future TODOs are captured in issues, which are referenced
@@ -29,16 +27,15 @@ your project.
 
 ## ✅ Pre-merge checklist ##
 
-<!-- Remove any of the following that do not apply. -->
-<!-- These boxes should remain unchecked until the pull request has been -->
-<!-- approved. -->
+- Remove any of the following that do not apply.
+- These boxes should remain unchecked until the pull request has been approved.
 
 - [ ] Bump version via the `bump_version.sh` script, if this
       repository is versioned.
 
 ## ✅ Post-merge checklist ##
 
-<!-- Remove any of the following that do not apply. -->
+- Remove any of the following that do not apply.
 
 - [ ] Create a release.
 

--- a/src/lineage/templates/clean_template.md
+++ b/src/lineage/templates/clean_template.md
@@ -27,8 +27,11 @@ your project.
 - Remove any of the following that do not apply.
 - These boxes should remain unchecked until the pull request has been approved.
 
-- [ ] Bump version via the `bump_version.sh` script, if this
-      repository is versioned.
+- [ ] Bump major, minor, patch, or pre-release version [as
+      appropriate](https://semver.org/#semantic-versioning-specification-semver)
+      via the `bump_version.sh` script *if* this repository is
+      versioned *and* the changes in this PR [warrant a version
+      bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
 
 ## ✅ Post-merge checklist ##
 

--- a/src/lineage/templates/conflict_template.md
+++ b/src/lineage/templates/conflict_template.md
@@ -50,7 +50,11 @@ that you must resolve before merging this pull request!
 
 1. Wait for all the automated tests to pass.
 
-1. Check the "Everything is cool" checkbox below.
+1. Confirm each item in the "Pre-approval checklist" below.
+
+1. Remove any of the checklist items that do not apply.
+
+1. Ensure every remaining checkbox has been checked.
 
 1. Mark this draft pull request "Ready for review".
 

--- a/src/lineage/templates/conflict_template.md
+++ b/src/lineage/templates/conflict_template.md
@@ -77,8 +77,11 @@ that you must resolve before merging this pull request!
 - Remove any of the following that do not apply.
 - These boxes should remain unchecked until the pull request has been approved.
 
-- [ ] Bump version via the `bump_version.sh` script, if this
-      repository is versioned.
+- [ ] Bump major, minor, patch, or pre-release version [as
+      appropriate](https://semver.org/#semantic-versioning-specification-semver)
+      via the `bump_version.sh` script *if* this repository is
+      versioned *and* the changes in this PR [warrant a version
+      bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
 
 ## ✅ Post-merge checklist ##
 

--- a/src/lineage/templates/conflict_template.md
+++ b/src/lineage/templates/conflict_template.md
@@ -50,11 +50,43 @@ that you must resolve before merging this pull request!
 
 1. Wait for all the automated tests to pass.
 
-1. Check the "Everything is cool" checkbox below:
-
-    - [ ] ✌️ The conflicts in this pull request have been resolved.
+1. Check the "Everything is cool" checkbox below.
 
 1. Mark this draft pull request "Ready for review".
+
+## ✅ Pre-approval checklist ##
+
+<!-- Remove any of the following that do not apply. -->
+<!-- Draft PRs should have one or more unchecked boxes. -->
+<!-- If you're unsure about any of these, don't hesitate to ask. -->
+<!-- We're here to help! -->
+
+- [ ] ✌️ The conflicts in this pull request have been resolved.
+- [ ] Changes are limited to a single goal - *eschew scope creep!*
+- [ ] *All* future TODOs are captured in issues, which are referenced
+      in code comments.
+- [ ] All relevant type-of-change labels have been added.
+- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
+- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
+- [ ] All relevant repo and/or project documentation has been updated
+      to reflect the changes in this PR.
+- [ ] Tests have been added and/or modified to cover the changes in this PR.
+- [ ] All new and existing tests pass.
+
+## ✅ Pre-merge checklist ##
+
+<!-- Remove any of the following that do not apply. -->
+<!-- These boxes should remain unchecked until the pull request has been -->
+<!-- approved. -->
+
+- [ ] Bump version via the `bump_version.sh` script, if this
+      repository is versioned.
+
+## ✅ Post-merge checklist ##
+
+<!-- Remove any of the following that do not apply. -->
+
+- [ ] Create a release.
 
 ---
 

--- a/src/lineage/templates/conflict_template.md
+++ b/src/lineage/templates/conflict_template.md
@@ -64,12 +64,9 @@ that you must resolve before merging this pull request!
 - If you're unsure about any of these, don't hesitate to ask. We're here to help!
 
 - [ ] ✌️ The conflicts in this pull request have been resolved.
-- [ ] Changes are limited to a single goal - *eschew scope creep!*
 - [ ] *All* future TODOs are captured in issues, which are referenced
       in code comments.
 - [ ] All relevant type-of-change labels have been added.
-- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
-- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
 - [ ] All relevant repo and/or project documentation has been updated
       to reflect the changes in this PR.
 - [ ] Tests have been added and/or modified to cover the changes in this PR.

--- a/src/lineage/templates/conflict_template.md
+++ b/src/lineage/templates/conflict_template.md
@@ -60,10 +60,8 @@ that you must resolve before merging this pull request!
 
 ## ✅ Pre-approval checklist ##
 
-<!-- Remove any of the following that do not apply. -->
-<!-- Draft PRs should have one or more unchecked boxes. -->
-<!-- If you're unsure about any of these, don't hesitate to ask. -->
-<!-- We're here to help! -->
+- Remove any of the following that do not apply.
+- If you're unsure about any of these, don't hesitate to ask. We're here to help!
 
 - [ ] ✌️ The conflicts in this pull request have been resolved.
 - [ ] Changes are limited to a single goal - *eschew scope creep!*
@@ -79,16 +77,15 @@ that you must resolve before merging this pull request!
 
 ## ✅ Pre-merge checklist ##
 
-<!-- Remove any of the following that do not apply. -->
-<!-- These boxes should remain unchecked until the pull request has been -->
-<!-- approved. -->
+- Remove any of the following that do not apply.
+- These boxes should remain unchecked until the pull request has been approved.
 
 - [ ] Bump version via the `bump_version.sh` script, if this
       repository is versioned.
 
 ## ✅ Post-merge checklist ##
 
-<!-- Remove any of the following that do not apply. -->
+- Remove any of the following that do not apply.
 
 - [ ] Create a release.
 


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds [the cisagov org's standard PR checklists](https://github.com/cisagov/.github/blob/develop/.github/pull_request_template.md) to the Lineage templates.

## 💭 Motivation and context ##

This change was triggered by the realization that one will likely need to bump the version and create a release after merging a Lineage PR for any versioned repositories.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [x] Finalize version.

## ✅ Post-merge checklist ##

- [ ] Create a release.
