### PR TITLE
Fix Markdown rendering

### DIFF
--- a/src/lineage/_version.py
+++ b/src/lineage/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this module."""
-__version__ = "0.2.1"
+__version__ = "0.2.2"

--- a/src/lineage/templates/clean_template.md
+++ b/src/lineage/templates/clean_template.md
@@ -11,8 +11,8 @@ your project.
 
 ## ✅ Pre-approval checklist ##
 
-- Remove any of the following that do not apply.
-- If you're unsure about any of these, don't hesitate to ask. We're here to help!
+Remove any of the following that do not apply. If you're unsure about
+any of these, don't hesitate to ask. We're here to help!
 
 - [ ] *All* future TODOs are captured in issues, which are referenced
       in code comments.
@@ -24,8 +24,8 @@ your project.
 
 ## ✅ Pre-merge checklist ##
 
-- Remove any of the following that do not apply.
-- These boxes should remain unchecked until the pull request has been approved.
+Remove any of the following that do not apply. These boxes should
+remain unchecked until the pull request has been approved.
 
 - [ ] Bump major, minor, patch, or pre-release version [as
       appropriate](https://semver.org/#semantic-versioning-specification-semver)
@@ -35,7 +35,7 @@ your project.
 
 ## ✅ Post-merge checklist ##
 
-- Remove any of the following that do not apply.
+Remove any of the following that do not apply.
 
 - [ ] Create a release.
 

--- a/src/lineage/templates/conflict_template.md
+++ b/src/lineage/templates/conflict_template.md
@@ -60,8 +60,8 @@ that you must resolve before merging this pull request!
 
 ## ✅ Pre-approval checklist ##
 
-- Remove any of the following that do not apply.
-- If you're unsure about any of these, don't hesitate to ask. We're here to help!
+Remove any of the following that do not apply. If you're unsure about
+any of these, don't hesitate to ask. We're here to help!
 
 - [ ] ✌️ The conflicts in this pull request have been resolved.
 - [ ] *All* future TODOs are captured in issues, which are referenced
@@ -74,8 +74,8 @@ that you must resolve before merging this pull request!
 
 ## ✅ Pre-merge checklist ##
 
-- Remove any of the following that do not apply.
-- These boxes should remain unchecked until the pull request has been approved.
+Remove any of the following that do not apply. These boxes should
+remain unchecked until the pull request has been approved.
 
 - [ ] Bump major, minor, patch, or pre-release version [as
       appropriate](https://semver.org/#semantic-versioning-specification-semver)
@@ -85,7 +85,7 @@ that you must resolve before merging this pull request!
 
 ## ✅ Post-merge checklist ##
 
-- Remove any of the following that do not apply.
+Remove any of the following that do not apply.
 
 - [ ] Create a release.
 


### PR DESCRIPTION
## 🗣 Description ##

This pull request adjusts the PR templates to get rid of an unsatisfying rendering, e.g. [here](https://github.com/cisagov/openvpn-packer/pull/85).

## 💭 Motivation and context ##

We avoid the use of two bulleted lists in a single section, as doing so seems to confuse Markdown and result in an unsatisfactory rendering.

## 🧪 Testing ##

I previewed the Markdown in `emacs` and it now appears normal.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [x] Finalize version.

## ✅ Post-merge checklist ##

- [x] Create a release.
