### PR TITLE
Use special GitHub-specific Markdown syntax for "Notes"

### DIFF
--- a/src/lineage/_version.py
+++ b/src/lineage/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this module."""
-__version__ = "0.2.2"
+__version__ = "0.2.3"

--- a/src/lineage/templates/clean_template.md
+++ b/src/lineage/templates/clean_template.md
@@ -41,8 +41,9 @@ Remove any of the following that do not apply.
 
 ---
 
-**Note:** *You are seeing this because one of this repository's maintainers has
-configured [Lineage] to open pull requests.*
+> **Note**
+> You are seeing this because one of this repository's maintainers has
+> configured [Lineage] to open pull requests.
 
 For more information:
 

--- a/src/lineage/templates/conflict_template.md
+++ b/src/lineage/templates/conflict_template.md
@@ -91,8 +91,9 @@ Remove any of the following that do not apply.
 
 ---
 
-**Note:** *You are seeing this because one of this repository's maintainers has
-configured [Lineage] to open pull requests.*
+> **Note**
+> You are seeing this because one of this repository's maintainers has
+> configured [Lineage] to open pull requests.
 
 For more information:
 


### PR DESCRIPTION
## 🗣 Description ##

This pull request tweaks the lineage PR templates to use a special "Note" syntax that is specific to GitHub Markdown syntax.

## 💭 Motivation and context ##

The new syntax better highlights the note in format that is expected by GitHub users.  Also consistency, since we are using this syntax [elsewhere](https://github.com/cisagov/development-guide/pull/87).

## 🧪 Testing ##

All automated tests pass.  I also previewed the templates in the GitHub web UI and verified that they appear as expected.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Post-merge checklist ##

- [x] Create a release.