### PR TITLE
Update GH-specific Markdown syntax

### DIFF
--- a/src/lineage/_version.py
+++ b/src/lineage/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this module."""
-__version__ = "0.2.5"
+__version__ = "0.2.6"

--- a/src/lineage/templates/clean_template.md
+++ b/src/lineage/templates/clean_template.md
@@ -42,7 +42,7 @@ Remove any of the following that do not apply.
 
 ---
 
-> **Note**
+> [!NOTE]
 > You are seeing this because one of this repository's maintainers has
 > configured [Lineage] to open pull requests.
 

--- a/src/lineage/templates/conflict_template.md
+++ b/src/lineage/templates/conflict_template.md
@@ -92,7 +92,7 @@ Remove any of the following that do not apply.
 
 ---
 
-> **Note**
+> [!NOTE]
 > You are seeing this because one of this repository's maintainers has
 > configured [Lineage] to open pull requests.
 


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates some GH-specific Markdown syntax.

## 💭 Motivation and context ##

The [original syntax has been updated](https://github.com/orgs/community/discussions/16925), and eventually the old style will no longer render.

## 🧪 Testing ##

:eyes: 

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Post-merge checklist ##

- [x] Create a release.
