### PR TITLE
Improve rendering of the templates in GitHub

### DIFF
--- a/src/lineage/_version.py
+++ b/src/lineage/_version.py
@@ -1,3 +1,3 @@
 """This file defines the version of this module."""
 
-__version__ = "2.0.1"
+__version__ = "2.0.2"

--- a/src/lineage/templates/clean_template.md
+++ b/src/lineage/templates/clean_template.md
@@ -1,50 +1,40 @@
 # Lineage Pull Request #
 
-[Lineage] has created this pull request to incorporate new changes found in an
-upstream repository:
+[Lineage] has created this pull request to incorporate new changes found in an upstream repository:  <!-- markdownlint-disable-line MD013 -->
 
 Upstream repository: [`{{ remote_url }}`]({{ remote_url }})
 {{#remote_branch}}Remote branch: `{{ remote_branch }}`{{/remote_branch}}
 
-Check the changes in this pull request to ensure they won't cause issues with
-your project.
+Check the changes in this pull request to ensure they won't cause issues with your project.  <!-- markdownlint-disable-line MD013 -->
 
 ## ✅ Pre-approval checklist ##
 
-Remove any of the following that do not apply. If you're unsure about
-any of these, don't hesitate to ask. We're here to help!
+Remove any of the following that do not apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!  <!-- markdownlint-disable-line MD013 -->
 
-- [ ] *All* future TODOs are captured in issues, which are referenced
-      in code comments.
+- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
 - [ ] All relevant type-of-change labels have been added.
-- [ ] All relevant repo and/or project documentation has been updated
-      to reflect the changes in this PR.
+- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.  <!-- markdownlint-disable-line MD013 -->
 - [ ] Tests have been added and/or modified to cover the changes in this PR.
 - [ ] All new and existing tests pass.
+- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).  <!-- markdownlint-disable-line MD013 -->
+- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).  <!-- markdownlint-disable-line MD013 -->
 
 ## ✅ Pre-merge checklist ##
 
-Remove any of the following that do not apply. These boxes should
-remain unchecked until the pull request has been approved.
+Remove any of the following that do not apply. These boxes should remain unchecked until the pull request has been approved.  <!-- markdownlint-disable-line MD013 -->
 
-- [ ] Bump major, minor, patch, or pre-release version [as
-      appropriate](https://semver.org/#semantic-versioning-specification-semver)
-      via the `bump_version.sh` script *if* this repository is
-      versioned *and* the changes in this PR [warrant a version
-      bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
 - [ ] Finalize version.
 
 ## ✅ Post-merge checklist ##
 
 Remove any of the following that do not apply.
 
-- [ ] Create a release.
+- [ ] Create a release (necessary if and only if the version was bumped).
 
 ---
 
 > [!NOTE]
-> You are seeing this because one of this repository's maintainers has
-> configured [Lineage] to open pull requests.
+> You are seeing this because one of this repository's maintainers has configured [Lineage] to open pull requests.  <!-- markdownlint-disable-line MD013 -->
 
 For more information:
 

--- a/src/lineage/templates/clean_template.md
+++ b/src/lineage/templates/clean_template.md
@@ -1,27 +1,36 @@
+<!-- GitHub renders PRs such that soft line breaks are treated as hard
+line breaks.  In order to make this template render as expected we
+therefore have to avoid soft breaks and therefore will offend
+markdownlint with long lines.  This is the reason for the markdownlint
+disable directive just below.
+
+For more details see:
+https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
+<!-- markdownlint-disable MD013 -->
 # Lineage Pull Request #
 
-[Lineage] has created this pull request to incorporate new changes found in an upstream repository:  <!-- markdownlint-disable-line MD013 -->
+[Lineage] has created this pull request to incorporate new changes found in an upstream repository:
 
 Upstream repository: [`{{ remote_url }}`]({{ remote_url }})
 {{#remote_branch}}Remote branch: `{{ remote_branch }}`{{/remote_branch}}
 
-Check the changes in this pull request to ensure they won't cause issues with your project.  <!-- markdownlint-disable-line MD013 -->
+Check the changes in this pull request to ensure they won't cause issues with your project.
 
 ## ✅ Pre-approval checklist ##
 
-Remove any of the following that do not apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!  <!-- markdownlint-disable-line MD013 -->
+Remove any of the following that do not apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
 
 - [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
 - [ ] All relevant type-of-change labels have been added.
-- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.  <!-- markdownlint-disable-line MD013 -->
+- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
 - [ ] Tests have been added and/or modified to cover the changes in this PR.
 - [ ] All new and existing tests pass.
-- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).  <!-- markdownlint-disable-line MD013 -->
-- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).  <!-- markdownlint-disable-line MD013 -->
+- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
+- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).
 
 ## ✅ Pre-merge checklist ##
 
-Remove any of the following that do not apply. These boxes should remain unchecked until the pull request has been approved.  <!-- markdownlint-disable-line MD013 -->
+Remove any of the following that do not apply. These boxes should remain unchecked until the pull request has been approved.
 
 - [ ] Finalize version.
 
@@ -34,7 +43,7 @@ Remove any of the following that do not apply.
 ---
 
 > [!NOTE]
-> You are seeing this because one of this repository's maintainers has configured [Lineage] to open pull requests.  <!-- markdownlint-disable-line MD013 -->
+> You are seeing this because one of this repository's maintainers has configured [Lineage] to open pull requests.
 
 For more information:
 

--- a/src/lineage/templates/conflict_template.md
+++ b/src/lineage/templates/conflict_template.md
@@ -2,17 +2,14 @@
 
 <img align="left" alt="Achtung!!!" width="100" src="https://raw.githubusercontent.com/cisagov/action-lineage/develop/src/achtung.gif">
 
-[Lineage] has created this pull request to incorporate new changes found in an
-upstream repository:
+[Lineage] has created this pull request to incorporate new changes found in an upstream repository:  <!-- markdownlint-disable-line MD013 -->
 
 Upstream repository: [`{{ remote_url }}`]({{ remote_url }})
 {{#remote_branch}}Remote branch: `{{ remote_branch }}`{{/remote_branch}}
 
-Check the changes in this pull request to ensure they won't cause issues with
-your project.
+Check the changes in this pull request to ensure they won't cause issues with your project.  <!-- markdownlint-disable-line MD013 -->
 
-The `{{ pr_branch_name }}` branch has **one or more unresolved merge conflicts**
-that you must resolve before merging this pull request!
+The `{{ pr_branch_name }}` branch has **one or more unresolved merge conflicts** that you must resolve before merging this pull request!  <!-- markdownlint-disable-line MD013 -->
 
 ## How to resolve the conflicts ##
 
@@ -31,11 +28,9 @@ that you must resolve before merging this pull request!
     git status
     ```
 
-1. Review the changes displayed by the `status` command.  Fix any conflicts and
-   possibly incorrect auto-merges.
+1. Review the changes displayed by the `status` command.  Fix any conflicts and possibly incorrect auto-merges.  <!-- markdownlint-disable-line MD013 -->
 
-1. After resolving each of the conflicts, `add` your changes to the
-   branch, `commit`, and `push` your changes:
+1. After resolving each of the conflicts, `add` your changes to the branch, `commit`, and `push` your changes:  <!-- markdownlint-disable-line MD013 -->
 
     ```console
     git add {{#conflict_file_list}}{{.}} {{/conflict_file_list}}
@@ -43,10 +38,7 @@ that you must resolve before merging this pull request!
     git push --force --set-upstream origin {{ pr_branch_name }}
     ```
 
-    Note that you may *append* to the default merge commit message
-    that git creates for you, but *please do not delete the existing
-    content*.  It provides useful information about the merge that is
-    being performed.
+    Note that you may *append* to the default merge commit message that git creates for you, but *please do not delete the existing content*.  It provides useful information about the merge that is being performed.  <!-- markdownlint-disable-line MD013 -->
 
 1. Wait for all the automated tests to pass.
 
@@ -60,8 +52,7 @@ that you must resolve before merging this pull request!
 
 ## ✅ Pre-approval checklist ##
 
-Remove any of the following that do not apply. If you're unsure about
-any of these, don't hesitate to ask. We're here to help!
+Remove any of the following that do not apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!  <!-- markdownlint-disable-line MD013 -->
 
 - [ ] ✌️ The conflicts in this pull request have been resolved.
 - [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
@@ -74,8 +65,7 @@ any of these, don't hesitate to ask. We're here to help!
 
 ## ✅ Pre-merge checklist ##
 
-Remove any of the following that do not apply. These boxes should
-remain unchecked until the pull request has been approved.
+Remove any of the following that do not apply. These boxes should remain unchecked until the pull request has been approved.  <!-- markdownlint-disable-line MD013 -->
 
 - [ ] Finalize version.
 
@@ -88,8 +78,7 @@ Remove any of the following that do not apply.
 ---
 
 > [!NOTE]
-> You are seeing this because one of this repository's maintainers has
-> configured [Lineage] to open pull requests.
+> You are seeing this because one of this repository's maintainers has configured [Lineage] to open pull requests.  <!-- markdownlint-disable-line MD013 -->
 
 For more information:
 

--- a/src/lineage/templates/conflict_template.md
+++ b/src/lineage/templates/conflict_template.md
@@ -1,15 +1,24 @@
+<!-- GitHub renders PRs such that soft line breaks are treated as hard
+line breaks.  In order to make this template render as expected we
+therefore have to avoid soft breaks and therefore will offend
+markdownlint with long lines.  This is the reason for the markdownlint
+disable directive just below.
+
+For more details see:
+https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
+<!-- markdownlint-disable MD013 -->
 # Lineage Pull Request: CONFLICT #
 
 <img align="left" alt="Achtung!!!" width="100" src="https://raw.githubusercontent.com/cisagov/action-lineage/develop/src/achtung.gif">
 
-[Lineage] has created this pull request to incorporate new changes found in an upstream repository:  <!-- markdownlint-disable-line MD013 -->
+[Lineage] has created this pull request to incorporate new changes found in an upstream repository:
 
 Upstream repository: [`{{ remote_url }}`]({{ remote_url }})
 {{#remote_branch}}Remote branch: `{{ remote_branch }}`{{/remote_branch}}
 
-Check the changes in this pull request to ensure they won't cause issues with your project.  <!-- markdownlint-disable-line MD013 -->
+Check the changes in this pull request to ensure they won't cause issues with your project.
 
-The `{{ pr_branch_name }}` branch has **one or more unresolved merge conflicts** that you must resolve before merging this pull request!  <!-- markdownlint-disable-line MD013 -->
+The `{{ pr_branch_name }}` branch has **one or more unresolved merge conflicts** that you must resolve before merging this pull request!
 
 ## How to resolve the conflicts ##
 
@@ -28,9 +37,9 @@ The `{{ pr_branch_name }}` branch has **one or more unresolved merge conflicts**
     git status
     ```
 
-1. Review the changes displayed by the `status` command.  Fix any conflicts and possibly incorrect auto-merges.  <!-- markdownlint-disable-line MD013 -->
+1. Review the changes displayed by the `status` command.  Fix any conflicts and possibly incorrect auto-merges.
 
-1. After resolving each of the conflicts, `add` your changes to the branch, `commit`, and `push` your changes:  <!-- markdownlint-disable-line MD013 -->
+1. After resolving each of the conflicts, `add` your changes to the branch, `commit`, and `push` your changes:
 
     ```console
     git add {{#conflict_file_list}}{{.}} {{/conflict_file_list}}
@@ -38,7 +47,7 @@ The `{{ pr_branch_name }}` branch has **one or more unresolved merge conflicts**
     git push --force --set-upstream origin {{ pr_branch_name }}
     ```
 
-    Note that you may *append* to the default merge commit message that git creates for you, but *please do not delete the existing content*.  It provides useful information about the merge that is being performed.  <!-- markdownlint-disable-line MD013 -->
+    Note that you may *append* to the default merge commit message that git creates for you, but *please do not delete the existing content*.  It provides useful information about the merge that is being performed.
 
 1. Wait for all the automated tests to pass.
 
@@ -52,20 +61,20 @@ The `{{ pr_branch_name }}` branch has **one or more unresolved merge conflicts**
 
 ## ✅ Pre-approval checklist ##
 
-Remove any of the following that do not apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!  <!-- markdownlint-disable-line MD013 -->
+Remove any of the following that do not apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
 
 - [ ] ✌️ The conflicts in this pull request have been resolved.
 - [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
 - [ ] All relevant type-of-change labels have been added.
-- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.  <!-- markdownlint-disable-line MD013 -->
+- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
 - [ ] Tests have been added and/or modified to cover the changes in this PR.
 - [ ] All new and existing tests pass.
-- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).  <!-- markdownlint-disable-line MD013 -->
-- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).  <!-- markdownlint-disable-line MD013 -->
+- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
+- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).
 
 ## ✅ Pre-merge checklist ##
 
-Remove any of the following that do not apply. These boxes should remain unchecked until the pull request has been approved.  <!-- markdownlint-disable-line MD013 -->
+Remove any of the following that do not apply. These boxes should remain unchecked until the pull request has been approved.
 
 - [ ] Finalize version.
 
@@ -78,7 +87,7 @@ Remove any of the following that do not apply.
 ---
 
 > [!NOTE]
-> You are seeing this because one of this repository's maintainers has configured [Lineage] to open pull requests.  <!-- markdownlint-disable-line MD013 -->
+> You are seeing this because one of this repository's maintainers has configured [Lineage] to open pull requests.
 
 For more information:
 

--- a/src/lineage/templates/conflict_template.md
+++ b/src/lineage/templates/conflict_template.md
@@ -64,31 +64,26 @@ Remove any of the following that do not apply. If you're unsure about
 any of these, don't hesitate to ask. We're here to help!
 
 - [ ] ✌️ The conflicts in this pull request have been resolved.
-- [ ] *All* future TODOs are captured in issues, which are referenced
-      in code comments.
+- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
 - [ ] All relevant type-of-change labels have been added.
-- [ ] All relevant repo and/or project documentation has been updated
-      to reflect the changes in this PR.
+- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.  <!-- markdownlint-disable-line MD013 -->
 - [ ] Tests have been added and/or modified to cover the changes in this PR.
 - [ ] All new and existing tests pass.
+- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).  <!-- markdownlint-disable-line MD013 -->
+- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).  <!-- markdownlint-disable-line MD013 -->
 
 ## ✅ Pre-merge checklist ##
 
 Remove any of the following that do not apply. These boxes should
 remain unchecked until the pull request has been approved.
 
-- [ ] Bump major, minor, patch, or pre-release version [as
-      appropriate](https://semver.org/#semantic-versioning-specification-semver)
-      via the `bump_version.sh` script *if* this repository is
-      versioned *and* the changes in this PR [warrant a version
-      bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
 - [ ] Finalize version.
 
 ## ✅ Post-merge checklist ##
 
 Remove any of the following that do not apply.
 
-- [ ] Create a release.
+- [ ] Create a release (necessary if and only if the version was bumped).
 
 ---
 


### PR DESCRIPTION
## 🗣 Description ##

This pull request:
- Adds a checklist item as a reminder to bump the version if appropriate.
- Adds checklist items as reminders to create a pre-release and a release if appropriate.
- Improves the rendering of the pull request template in GitHub.

See also cisagov/.github#70.

## 💭 Motivation and context ##

- Now that all of our projects have a version associated with them it is important to have a reminder to bump the version when appropriate.
- With the version bump reminder it makes sense to have these reminders as well.
- The list items no longer appear artificially shortened and instead can be rendered as markdown sees fit.  This is something I have been correcting manually in my PRs for years.

## 🧪 Testing ##

All automated tests should pass once #81 is approved and merged.  I also viewed the updated versions of [`conflict_template.md`](https://github.com/cisagov/action-lineage/blob/improvement/improve-rendering-in-github/src/lineage/templates/conflict_template.md) and [`clean_template.md`](https://github.com/cisagov/action-lineage/blob/improvement/improve-rendering-in-github/src/lineage/templates/clean_template.md) with my ocular orbs and verified that they appear correct.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
- [x] Bump the patch version.

## ✅ Pre-merge checklist ##

- [x] Finalize version.

## ✅ Post-merge checklist ##

- [x] Create a release.
