### PR TITLE
Run only after working hours

### DIFF
--- a/.github/workflows/lineage_scan.yml
+++ b/.github/workflows/lineage_scan.yml
@@ -3,7 +3,7 @@ name: lineage_scan
 
 on:  # yamllint disable-line rule:truthy
   schedule:
-    - cron: 15 * * * *
+    - cron: 15 0-4 * * *
   workflow_dispatch:
 
 # Set a default shell for any run steps. The `-Eueo pipefail` sets errtrace,


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the `lineage_scan` workflow to only run between midnight and 4AM UTC.

## 💭 Motivation and context ##

We have seen the Lineage jobs hog all the runners when building many skeleton descendants, so to alleviate this we run the `lineage_scan` workflow only between midnight and 4AM UTC.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.