### PR TITLE
Adapt `.dockerignore` for `pyproject.toml` vice `setup.py`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 *
+!pyproject.toml
 !README.md
 !requirements.txt
-!setup.py
 !src

--- a/src/lineage/_version.py
+++ b/src/lineage/_version.py
@@ -1,3 +1,3 @@
 """This file defines the version of this module."""
 
-__version__ = "3.0.0"
+__version__ = "3.0.1"


### PR DESCRIPTION
## 🗣 Description ##

This pull request adapts the `.dockerignore` file for the use of `pyproject.toml` vice `setup.py`.  This fixes a bug that was preventing the `lineage_scan.yml` workflow from running successfully.

## 💭 Motivation and context ##

With the previous contents the `.dockerignore` was preventing the Docker image from being built.  This was because the `pyproject.toml` file wasn't being sent to Docker as part of the build context.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).

## ✅ Pre-merge checklist ##

- [x] Finalize version.

## ✅ Post-merge checklist ##

- [x] Create a release (necessary if and only if the version was bumped).
